### PR TITLE
Remove duplicate entry in `TypesWithUndefinedEquality#SPARSE_ARRAY`

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypesWithUndefinedEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypesWithUndefinedEquality.java
@@ -29,13 +29,13 @@ public enum TypesWithUndefinedEquality {
   DATE("Date", "java.util.Date"),
   IMMUTABLE_COLLECTION("ImmutableCollection", "com.google.common.collect.ImmutableCollection"),
   IMMUTABLE_MULTIMAP("ImmutableMultimap", "com.google.common.collect.ImmutableMultimap"),
-  ITERABLE("Iterable", "java.lang.Iterable", "com.google.common.collect.FluentIterable"),
+  ITERABLE("Iterable", "com.google.common.collect.FluentIterable", "java.lang.Iterable"),
   LONG_SPARSE_ARRAY(
       "LongSparseArray",
-      "android.util.LongSparseArray",
       "android.support.v4.util.LongSparseArrayCompat",
-      "androidx.core.util.LongSparseArrayCompat",
-      "androidx.collection.LongSparseArrayCompat"),
+      "android.util.LongSparseArray",
+      "androidx.collection.LongSparseArrayCompat",
+      "androidx.core.util.LongSparseArrayCompat"),
   MULTIMAP("Multimap", "com.google.common.collect.Multimap"),
   QUEUE("Queue", "java.util.Queue"),
   SPARSE_ARRAY("SparseArray", "android.util.SparseArray", "androidx.collection.SparseArrayCompat");

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypesWithUndefinedEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypesWithUndefinedEquality.java
@@ -24,25 +24,25 @@ import com.sun.tools.javac.code.Type;
 
 /** Enumerates types which have poorly-defined behaviour for equals. */
 public enum TypesWithUndefinedEquality {
+  CHAR_SEQUENCE("CharSequence", "java.lang.CharSequence"),
+  COLLECTION("Collection", "java.util.Collection"),
+  DATE("Date", "java.util.Date"),
+  IMMUTABLE_COLLECTION("ImmutableCollection", "com.google.common.collect.ImmutableCollection"),
+  IMMUTABLE_MULTIMAP("ImmutableMultimap", "com.google.common.collect.ImmutableMultimap"),
+  ITERABLE("Iterable", "java.lang.Iterable", "com.google.common.collect.FluentIterable"),
   LONG_SPARSE_ARRAY(
       "LongSparseArray",
       "android.util.LongSparseArray",
       "android.support.v4.util.LongSparseArrayCompat",
       "androidx.core.util.LongSparseArrayCompat",
       "androidx.collection.LongSparseArrayCompat"),
+  MULTIMAP("Multimap", "com.google.common.collect.Multimap"),
+  QUEUE("Queue", "java.util.Queue"),
   SPARSE_ARRAY(
       "SparseArray",
       "android.util.SparseArray",
       "androidx.collection.SparseArrayCompat",
-      "androidx.collection.SparseArrayCompat"),
-  MULTIMAP("Multimap", "com.google.common.collect.Multimap"),
-  IMMUTABLE_MULTIMAP("ImmutableMultimap", "com.google.common.collect.ImmutableMultimap"),
-  CHAR_SEQUENCE("CharSequence", "java.lang.CharSequence"),
-  ITERABLE("Iterable", "java.lang.Iterable", "com.google.common.collect.FluentIterable"),
-  COLLECTION("Collection", "java.util.Collection"),
-  IMMUTABLE_COLLECTION("ImmutableCollection", "com.google.common.collect.ImmutableCollection"),
-  QUEUE("Queue", "java.util.Queue"),
-  DATE("Date", "java.util.Date");
+      "androidx.collection.SparseArrayCompat");
 
   private final String shortName;
   private final ImmutableSet<String> typeNames;

--- a/core/src/main/java/com/google/errorprone/bugpatterns/TypesWithUndefinedEquality.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/TypesWithUndefinedEquality.java
@@ -38,11 +38,7 @@ public enum TypesWithUndefinedEquality {
       "androidx.collection.LongSparseArrayCompat"),
   MULTIMAP("Multimap", "com.google.common.collect.Multimap"),
   QUEUE("Queue", "java.util.Queue"),
-  SPARSE_ARRAY(
-      "SparseArray",
-      "android.util.SparseArray",
-      "androidx.collection.SparseArrayCompat",
-      "androidx.collection.SparseArrayCompat");
+  SPARSE_ARRAY("SparseArray", "android.util.SparseArray", "androidx.collection.SparseArrayCompat");
 
   private final String shortName;
   private final ImmutableSet<String> typeNames;


### PR DESCRIPTION
While there:
- Remove duplicate entry of `TypesWithUndefinedEquality#SPARSE_ARRAY`
- Sort the enum
- Sort the values of the enum

When opening the PR, add the following comment (open to suggestions): 
> Should we add `java.lang.Object` to the `TypesWithUndefinedEquality` enum? 
