### PR TITLE
Unify real expression in `U{FreeIdent,Repeated}Test` 

### DIFF
--- a/core/src/test/java/com/google/errorprone/refaster/UFreeIdentTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/UFreeIdentTest.java
@@ -25,9 +25,9 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
-import com.google.errorprone.bugpatterns.BugChecker.ExpressionStatementTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
-import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.util.Context;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,16 +66,14 @@ public class UFreeIdentTest extends AbstractUTreeTest {
       summary = "Verify that unifying the expression results in the correct binding",
       explanation = "For test purposes only",
       severity = SUGGESTION)
-  public static class UnificationChecker extends BugChecker
-      implements ExpressionStatementTreeMatcher {
+  public static class UnificationChecker extends BugChecker implements MethodInvocationTreeMatcher {
     @Override
-    public Description matchExpressionStatement(ExpressionStatementTree tree, VisitorState state) {
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
       Unifier unifier = new Unifier(new Context());
       UFreeIdent ident = UFreeIdent.create("foo");
 
-      assertThat(ident.unify(tree.getExpression(), unifier)).isNotNull();
-      assertThat(unifier.getBindings())
-          .containsExactly(new UFreeIdent.Key("foo"), tree.getExpression());
+      assertThat(ident.unify(tree, unifier)).isNotNull();
+      assertThat(unifier.getBindings()).containsExactly(new UFreeIdent.Key("foo"), tree);
 
       return Description.NO_MATCH;
     }

--- a/core/src/test/java/com/google/errorprone/refaster/UFreeIdentTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/UFreeIdentTest.java
@@ -49,7 +49,7 @@ public class UFreeIdentTest extends AbstractUTreeTest {
 
   @Test
   public void binds() {
-    CompilationTestHelper.newInstance(DummyChecker.class, getClass())
+    CompilationTestHelper.newInstance(UnificationChecker.class, getClass())
         .addSourceLines(
             "A.java",
             "class A {",
@@ -62,10 +62,12 @@ public class UFreeIdentTest extends AbstractUTreeTest {
   }
 
   @BugPattern(
+      name = "UnificationChecker",
       summary = "Verify that unifying the expression results in the correct binding",
       explanation = "For test purposes only",
       severity = SUGGESTION)
-  public static class DummyChecker extends BugChecker implements ExpressionStatementTreeMatcher {
+  public static class UnificationChecker extends BugChecker
+      implements ExpressionStatementTreeMatcher {
     @Override
     public Description matchExpressionStatement(ExpressionStatementTree tree, VisitorState state) {
       Unifier unifier = new Unifier(new Context());

--- a/core/src/test/java/com/google/errorprone/refaster/URepeatedTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/URepeatedTest.java
@@ -39,7 +39,7 @@ public class URepeatedTest extends AbstractUTreeTest {
 
   @Test
   public void unifies() {
-    CompilationTestHelper.newInstance(DummyChecker.class, getClass())
+    CompilationTestHelper.newInstance(UnificationChecker.class, getClass())
         .addSourceLines(
             "A.java",
             "class A {",
@@ -52,10 +52,12 @@ public class URepeatedTest extends AbstractUTreeTest {
   }
 
   @BugPattern(
+      name = "UnificationChecker",
       summary = "Verify that unifying the expression results in the correct binding",
       explanation = "For test purposes only",
       severity = SUGGESTION)
-  public static class DummyChecker extends BugChecker implements ExpressionStatementTreeMatcher {
+  public static class UnificationChecker extends BugChecker
+      implements ExpressionStatementTreeMatcher {
     @Override
     public Description matchExpressionStatement(ExpressionStatementTree tree, VisitorState state) {
       Unifier unifier = new Unifier(new Context());

--- a/core/src/test/java/com/google/errorprone/refaster/URepeatedTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/URepeatedTest.java
@@ -25,9 +25,9 @@ import com.google.errorprone.BugPattern;
 import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
-import com.google.errorprone.bugpatterns.BugChecker.ExpressionStatementTreeMatcher;
+import com.google.errorprone.bugpatterns.BugChecker.MethodInvocationTreeMatcher;
 import com.google.errorprone.matchers.Description;
-import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.tools.javac.util.Context;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,16 +56,14 @@ public class URepeatedTest extends AbstractUTreeTest {
       summary = "Verify that unifying the expression results in the correct binding",
       explanation = "For test purposes only",
       severity = SUGGESTION)
-  public static class UnificationChecker extends BugChecker
-      implements ExpressionStatementTreeMatcher {
+  public static class UnificationChecker extends BugChecker implements MethodInvocationTreeMatcher {
     @Override
-    public Description matchExpressionStatement(ExpressionStatementTree tree, VisitorState state) {
+    public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
       Unifier unifier = new Unifier(new Context());
       URepeated ident = URepeated.create("foo", UFreeIdent.create("foo"));
 
-      assertThat(ident.unify(tree.getExpression(), unifier)).isNotNull();
-      assertThat(unifier.getBindings())
-          .containsExactly(new UFreeIdent.Key("foo"), tree.getExpression());
+      assertThat(ident.unify(tree, unifier)).isNotNull();
+      assertThat(unifier.getBindings()).containsExactly(new UFreeIdent.Key("foo"), tree);
 
       return Description.NO_MATCH;
     }

--- a/core/src/test/java/com/google/errorprone/refaster/URepeatedTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/URepeatedTest.java
@@ -17,10 +17,18 @@
 package com.google.errorprone.refaster;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.SerializableTester;
-import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.ExpressionStatementTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ExpressionStatementTree;
+import com.sun.tools.javac.util.Context;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,10 +39,34 @@ public class URepeatedTest extends AbstractUTreeTest {
 
   @Test
   public void unifies() {
-    JCExpression expr = parseExpression("\"abcdefg\".charAt(x + 1)");
-    URepeated ident = URepeated.create("foo", UFreeIdent.create("foo"));
-    assertThat(ident.unify(expr, unifier)).isNotNull();
-    assertThat(unifier.getBindings()).containsExactly(new UFreeIdent.Key("foo"), expr);
+    CompilationTestHelper.newInstance(DummyChecker.class, getClass())
+        .addSourceLines(
+            "A.java",
+            "class A {",
+            "  public void bar() {",
+            "    int x = 0;",
+            "    \"abcdefg\".charAt(x + 1);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @BugPattern(
+      summary = "Verify that unifying the expression results in the correct binding",
+      explanation = "For test purposes only",
+      severity = SUGGESTION)
+  public static class DummyChecker extends BugChecker implements ExpressionStatementTreeMatcher {
+    @Override
+    public Description matchExpressionStatement(ExpressionStatementTree tree, VisitorState state) {
+      Unifier unifier = new Unifier(new Context());
+      URepeated ident = URepeated.create("foo", UFreeIdent.create("foo"));
+
+      assertThat(ident.unify(tree.getExpression(), unifier)).isNotNull();
+      assertThat(unifier.getBindings())
+          .containsExactly(new UFreeIdent.Key("foo"), tree.getExpression());
+
+      return Description.NO_MATCH;
+    }
   }
 
   @Test


### PR DESCRIPTION
❗ This PR is on top of #4 ❗ 

In #4 we introduce additional logic to filter out invalid expressions in `UFreeIdent`, see [here](https://github.com/PicnicSupermarket/error-prone/pull/4/files#diff-c3a74c9db7afc4167341ba2e43064a28d9ffe2dfe6bfcddddf0ecdad9e562174R104-R109). 
However, when [this code](https://github.com/PicnicSupermarket/error-prone/blob/master/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java#L301-L304) got introduced in this commit https://github.com/PicnicSupermarket/error-prone/commit/c2e14f24facfae7a0e38e78dd4005f25c7f4f8b4, it broke our code. 

The test cases in the `UFreeIdentTest` and `URepeatedTest` are not "valid"/"realistic" enough and therefore results in an `IllegalArgumentException` in `ASTHelpers#getSymbol(MethodInvocationTree)`.  

To make our code compatible with this change, we changed the tests to use `BugChecker`s for the two tests. This way we can use the same assertions but use _real_ expressions that are accepted by `ASTHelpers#getSymbol`. 

Once we merge this PR we can also rebase #4 with `master`.

