### PR TITLE
BuilderReturnThis: Don't flag already annotated builder methods

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/checkreturnvalue/BuilderReturnThis.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/checkreturnvalue/BuilderReturnThis.java
@@ -21,6 +21,7 @@ import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.fixes.SuggestedFixes.qualifyType;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 import static com.google.errorprone.util.ASTHelpers.getSymbol;
+import static com.google.errorprone.util.ASTHelpers.hasAnnotation;
 import static com.google.errorprone.util.ASTHelpers.isSameType;
 import static com.google.errorprone.util.ASTHelpers.isSubtype;
 import static java.lang.Boolean.TRUE;
@@ -56,6 +57,9 @@ public class BuilderReturnThis extends BugChecker implements MethodTreeMatcher {
     MethodSymbol sym = getSymbol(tree);
     if (tree.getBody() == null) {
       return NO_MATCH;
+    }
+    if (hasAnnotation(tree, CRV, state)) {
+      return Description.NO_MATCH;
     }
     if (!instanceReturnsBuilder(sym, state)) {
       return NO_MATCH;

--- a/core/src/test/java/com/google/errorprone/bugpatterns/checkreturnvalue/BuilderReturnThisTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/checkreturnvalue/BuilderReturnThisTest.java
@@ -32,6 +32,8 @@ public class BuilderReturnThisTest {
     testHelper
         .addInputLines(
             "Test.java",
+            "import com.google.errorprone.annotations.CheckReturnValue;",
+            "",
             "class Test {",
             "  static class TestBuilder {",
             "    static TestBuilder builder() {",
@@ -57,6 +59,10 @@ public class BuilderReturnThisTest {
             "    }",
             "    TestBuilder setParens(String bar) {",
             "      return (this);",
+            "    }",
+            "    @CheckReturnValue",
+            "    TestBuilder dontFlag(String flag) {",
+            "      return new TestBuilder();",
             "    }",
             "  }",
             "}")


### PR DESCRIPTION
It's similar to the extra check in [CanIgnoreReturnValueSuggester](https://github.com/PicnicSupermarket/error-prone/blob/master/core/src/main/java/com/google/errorprone/bugpatterns/checkreturnvalue/CanIgnoreReturnValueSuggester.java#L93-L96).