### PR TITLE
Prevent Refaster on JDK 17 from throwing a `LinkageError`

### DIFF
--- a/core/src/main/java/com/google/errorprone/refaster/PlaceholderUnificationVisitor.java
+++ b/core/src/main/java/com/google/errorprone/refaster/PlaceholderUnificationVisitor.java
@@ -676,7 +676,7 @@ abstract class PlaceholderUnificationVisitor
             TreeMaker.class
                 .getMethod(
                     "Case",
-                    Class.forName("com.sun.source.tree.CaseTree.CaseKind"),
+                    Class.forName("com.sun.source.tree.CaseTree$CaseKind"),
                     List.class,
                     List.class,
                     JCTree.class)

--- a/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
@@ -374,4 +374,9 @@ public class TemplateIntegrationTest extends CompilerBasedTest {
   public void typeArgumentsMethodInvocation() throws IOException {
     runTest("TypeArgumentsMethodInvocationTemplate");
   }
+
+  @Test
+  public void caseKindLinkageError() throws IOException {
+    runTest("CaseKindLinkageErrorTemplate");
+  }
 }

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/input/CaseKindLinkageErrorTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/input/CaseKindLinkageErrorTemplateExample.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+/** Test data for {@code CaseKindLinkageErrorTemplate}. */
+public class CaseKindLinkageErrorTemplateExample {
+  public void foo() {
+    String s = "";
+    if (s.isEmpty()) {
+      switch (s.length()) {
+        case 0:
+          s.toString();
+      }
+    }
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/output/CaseKindLinkageErrorTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/output/CaseKindLinkageErrorTemplateExample.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+/** Test data for {@code CaseKindLinkageErrorTemplate}. */
+public class CaseKindLinkageErrorTemplateExample {
+  public void foo() {
+    String s = "";
+    if (s.isEmpty()) {
+      switch (s.length()) {
+        case 0:
+          s.toString();
+      }
+    }
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/template/CaseKindLinkageErrorTemplate.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/template/CaseKindLinkageErrorTemplate.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata.template;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.MayOptionallyUse;
+import com.google.errorprone.refaster.annotation.Placeholder;
+
+/**
+ * Template to show a {@link LinkageError} related to {@code CaseTree.CaseKind} when running
+ * Refaster on Java 17.
+ */
+abstract class CaseKindLinkageErrorTemplate {
+  @Placeholder
+  abstract void placeholder(@MayOptionallyUse String s);
+
+  @BeforeTemplate
+  void before(String s) {
+    if (s.isEmpty()) {
+      placeholder(s);
+    }
+  }
+
+  @AfterTemplate
+  void after(String s) {
+    if (s.isEmpty()) {
+      placeholder(s);
+    }
+  }
+}


### PR DESCRIPTION
This problem occurs when the `PlaceholderUnificationVisitor` visits a switch case.

Fixes #3553.