### PR TITLE
BadImport: Add `newInstance` to `BAD_STATIC_IDENTIFIERS`

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/BadImport.java
@@ -82,6 +82,7 @@ public class BadImport extends BugChecker implements ImportTreeMatcher {
           "getDefaultInstance",
           "INSTANCE",
           "newBuilder",
+          "newInstance",
           "of",
           "valueOf");
 

--- a/core/src/test/java/com/google/errorprone/bugpatterns/BadImportTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/BadImportTest.java
@@ -45,6 +45,23 @@ public final class BadImportTest {
   }
 
   @Test
+  public void positive_identifiers() {
+    compilationTestHelper
+        .addSourceLines(
+            "Test.java",
+            "import static com.google.errorprone.CompilationTestHelper.newInstance;",
+            "import com.google.errorprone.CompilationTestHelper;",
+            "import com.google.errorprone.bugpatterns.BugChecker;",
+            "",
+            "class Test {",
+            "  private final CompilationTestHelper compilationTestHelper =",
+            "      // BUG: Diagnostic contains: CompilationTestHelper.newInstance",
+            "      newInstance(BugChecker.class, getClass());",
+            "}")
+        .doTest();
+  }
+
+  @Test
   public void msg() {
     compilationTestHelper
         .addSourceLines(


### PR DESCRIPTION
We now almost have our own version of this check as well. Do we still want to upstream this one? I think it would still be a nice improvement.