### PR TITLE
 Ensure proper selection of the name identifier during method renaming with `SuggestedFixes#renameMethod`

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -745,17 +745,14 @@ public final class SuggestedFixes {
 
   /** Be warned, only changes method name at the declaration. */
   public static SuggestedFix renameMethod(MethodTree tree, String replacement, VisitorState state) {
-    // Search tokens from beginning of method tree to beginning of method body.
-    int basePos = getStartPosition(tree);
+    // Search tokens from end of return type tree to beginning of method body.
+    int basePos = state.getEndPosition(tree.getReturnType());
     int endPos =
         tree.getBody() != null ? getStartPosition(tree.getBody()) : state.getEndPosition(tree);
     List<ErrorProneToken> methodTokens = state.getOffsetTokens(basePos, endPos);
 
-    int returnTypeEndPos = state.getEndPosition(tree.getReturnType());
     for (ErrorProneToken token : methodTokens) {
-      if (token.kind() == TokenKind.IDENTIFIER
-          && token.pos() > returnTypeEndPos
-          && token.name().equals(tree.getName())) {
+      if (token.kind() == TokenKind.IDENTIFIER && token.name().equals(tree.getName())) {
         return SuggestedFix.replace(token.pos(), token.endPos(), replacement);
       }
     }

--- a/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/SuggestedFixes.java
@@ -750,8 +750,12 @@ public final class SuggestedFixes {
     int endPos =
         tree.getBody() != null ? getStartPosition(tree.getBody()) : state.getEndPosition(tree);
     List<ErrorProneToken> methodTokens = state.getOffsetTokens(basePos, endPos);
+
+    int returnTypeEndPos = state.getEndPosition(tree.getReturnType());
     for (ErrorProneToken token : methodTokens) {
-      if (token.kind() == TokenKind.IDENTIFIER && token.name().equals(tree.getName())) {
+      if (token.kind() == TokenKind.IDENTIFIER
+          && token.pos() > returnTypeEndPos
+          && token.name().equals(tree.getName())) {
         return SuggestedFix.replace(token.pos(), token.endPos(), replacement);
       }
     }

--- a/core/src/test/java/com/google/errorprone/bugpatterns/MemberNameTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/MemberNameTest.java
@@ -463,4 +463,32 @@ public class MemberNameTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void methodNameWithMatchingReturnType() {
+    refactoringHelper
+        .addInputLines(
+            "Test.java",
+            "class Test {",
+            "  private Object Object() {",
+            "    return null;",
+            "  }",
+            "",
+            "  void call() {",
+            "     Object();",
+            "  }",
+            "}")
+        .addOutputLines(
+            "Test.java",
+            "class Test {",
+            "  private Object object() {",
+            "    return null;",
+            "  }",
+            "",
+            "  void call() {",
+            "     object();",
+            "  }",
+            "}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
By asserting, the identifier token position is after the end position of the return type identifier.