### PR TITLE
Have `UAnyOf#accept` invoke `TreeVisitor#visitOther`

### DIFF
--- a/core/src/main/java/com/google/errorprone/refaster/UAnyOf.java
+++ b/core/src/main/java/com/google/errorprone/refaster/UAnyOf.java
@@ -64,7 +64,7 @@ public abstract class UAnyOf extends UExpression {
 
   @Override
   public <R, D> R accept(TreeVisitor<R, D> visitor, D data) {
-    return expressions().get(0).accept(visitor, data);
+    return visitor.visitOther(this, data);
   }
 
   @Override


### PR DESCRIPTION
In PicnicSupermarket/error-prone-support#261 we're developing an approach to speed up Refaster. The idea is to first index all identifiers referenced by Refaster `@BeforeTemplate`s and then use the identifiers found in a compilation unit under consideration to select the subset of Refaster rules that have a nonzero probability of matching.

While working on this, we noticed that `UAnyOf#accept(TreeVisitor, Object)` descends only into the first expression passed to `Refaster#anyOf`. This PR proposes that `TreeVisitor#visitOther` is invoked instead. This allows the visitor to implement proper support for `UAnyOf` if desired. With this change, all public Error Prone unit tests still pass. We hope that this change is also compatible with Google-internal code. Naturally, we are open to alternatives that would allow visiting all `UAnyOf` subtrees.

In the context of this same project, we have another question regarding some non-public types and methods of the Refaster implementation. Currently, we're using [reflection](https://github.com/PicnicSupermarket/error-prone-support/blob/9673572114e6d2652334877dabcc32e87da5e152/refaster-runner/src/main/java/tech/picnic/errorprone/refaster/runner/RefasterRuleSelector.java#L247) to access some of these. Ideally, we avoid this approach. Would you be open to increasing the visibility of certain types and methods?